### PR TITLE
[#48] Default values for variables of SecurityConfiguration

### DIFF
--- a/src/main/java/com/paypal/security/SecurityConfiguration.java
+++ b/src/main/java/com/paypal/security/SecurityConfiguration.java
@@ -37,6 +37,15 @@ public class SecurityConfiguration {
   private static final String SEC_PROPERTIES = "security.properties";
   private final Properties properties = new Properties();
 
+  private static final String NNA_PORT = "8080";
+  private static final String NNA_HISTORICAL = "false";
+  private static final String LDAP_ENABLED = "false";
+  private static final String AUTHORIZATION_ENABLED = "false";
+  private static final String LDAP_USE_STARTTLS = "false";
+  private static final String LDAP_CONNECT_TIMEOUT = "1000";
+  private static final String LDAP_RESPONSE_TIMEOUT = "1000";
+  private static final String NNA_SUGGESTIONS_RELOAD_TIMEOUT = "900000";
+
   public SecurityConfiguration() {
     InputStream input = this.getClass().getClassLoader().getResourceAsStream(SEC_PROPERTIES);
     try {
@@ -47,15 +56,16 @@ public class SecurityConfiguration {
   }
 
   public boolean getHistoricalEnabled() {
-    return Boolean.parseBoolean(properties.getProperty("nna.historical"));
+    return Boolean.parseBoolean(properties.getProperty("nna.historical", NNA_HISTORICAL));
   }
 
   public boolean getAuthorizationEnabled() {
-    return Boolean.parseBoolean(properties.getProperty("authorization.enable"));
+    return Boolean.parseBoolean(
+        properties.getProperty("authorization.enable", AUTHORIZATION_ENABLED));
   }
 
   public boolean getLdapEnabled() {
-    return Boolean.parseBoolean(properties.getProperty("ldap.enable"));
+    return Boolean.parseBoolean(properties.getProperty("ldap.enable", LDAP_ENABLED));
   }
 
   public String getLdapUrl() {
@@ -82,15 +92,15 @@ public class SecurityConfiguration {
   }
 
   public boolean getLdapUseStartTLS() {
-    return Boolean.parseBoolean(properties.getProperty("ldap.use.starttls"));
+    return Boolean.parseBoolean(properties.getProperty("ldap.use.starttls", LDAP_USE_STARTTLS));
   }
 
   public int getLdapConnectTimeout() {
-    return Integer.parseInt(properties.getProperty("ldap.connect.timeout"));
+    return Integer.parseInt(properties.getProperty("ldap.connect.timeout", LDAP_CONNECT_TIMEOUT));
   }
 
   public int getLdapResponseTimeout() {
-    return Integer.parseInt(properties.getProperty("ldap.response.timeout"));
+    return Integer.parseInt(properties.getProperty("ldap.response.timeout", LDAP_RESPONSE_TIMEOUT));
   }
 
   public int getLdapConnectionPoolMinSize() {
@@ -102,7 +112,8 @@ public class SecurityConfiguration {
   }
 
   public int getSuggestionsReloadSleepMs() {
-    return Integer.parseInt(properties.getProperty("nna.suggestions.reload.sleep.ms"));
+    return Integer.parseInt(
+        properties.getProperty("nna.suggestions.reload.sleep.ms", NNA_SUGGESTIONS_RELOAD_TIMEOUT));
   }
 
   public String getJwtSignatureSecret() {
@@ -182,7 +193,7 @@ public class SecurityConfiguration {
   }
 
   public int getPort() {
-    return Integer.parseInt(properties.getProperty("nna.port"));
+    return Integer.parseInt(properties.getProperty("nna.port", NNA_PORT));
   }
 
   public String getHistoricalUsername() {

--- a/src/main/java/com/paypal/security/SecurityConfiguration.java
+++ b/src/main/java/com/paypal/security/SecurityConfiguration.java
@@ -37,14 +37,14 @@ public class SecurityConfiguration {
   private static final String SEC_PROPERTIES = "security.properties";
   private final Properties properties = new Properties();
 
-  private static final String NNA_PORT = "8080";
-  private static final String NNA_HISTORICAL = "false";
-  private static final String LDAP_ENABLED = "false";
-  private static final String AUTHORIZATION_ENABLED = "false";
-  private static final String LDAP_USE_STARTTLS = "false";
-  private static final String LDAP_CONNECT_TIMEOUT = "1000";
-  private static final String LDAP_RESPONSE_TIMEOUT = "1000";
-  private static final String NNA_SUGGESTIONS_RELOAD_TIMEOUT = "900000";
+  private static final String NNA_PORT_DEFAULT = "8080";
+  private static final String NNA_HISTORICAL_DEFAULT = "false";
+  private static final String LDAP_ENABLED_DEFAULT = "false";
+  private static final String AUTHORIZATION_ENABLED_DEFAULT = "false";
+  private static final String LDAP_USE_STARTTLS_DEFAULT = "false";
+  private static final String LDAP_CONNECT_TIMEOUT_DEFAULT = "1000";
+  private static final String LDAP_RESPONSE_TIMEOUT_DEFAULT = "1000";
+  private static final String NNA_SUGGESTIONS_RELOAD_TIMEOUT_DEFAULT = "900000";
 
   public SecurityConfiguration() {
     InputStream input = this.getClass().getClassLoader().getResourceAsStream(SEC_PROPERTIES);
@@ -56,16 +56,16 @@ public class SecurityConfiguration {
   }
 
   public boolean getHistoricalEnabled() {
-    return Boolean.parseBoolean(properties.getProperty("nna.historical", NNA_HISTORICAL));
+    return Boolean.parseBoolean(properties.getProperty("nna.historical", NNA_HISTORICAL_DEFAULT));
   }
 
   public boolean getAuthorizationEnabled() {
     return Boolean.parseBoolean(
-        properties.getProperty("authorization.enable", AUTHORIZATION_ENABLED));
+        properties.getProperty("authorization.enable", AUTHORIZATION_ENABLED_DEFAULT));
   }
 
   public boolean getLdapEnabled() {
-    return Boolean.parseBoolean(properties.getProperty("ldap.enable", LDAP_ENABLED));
+    return Boolean.parseBoolean(properties.getProperty("ldap.enable", LDAP_ENABLED_DEFAULT));
   }
 
   public String getLdapUrl() {
@@ -92,15 +92,18 @@ public class SecurityConfiguration {
   }
 
   public boolean getLdapUseStartTLS() {
-    return Boolean.parseBoolean(properties.getProperty("ldap.use.starttls", LDAP_USE_STARTTLS));
+    return Boolean.parseBoolean(
+        properties.getProperty("ldap.use.starttls", LDAP_USE_STARTTLS_DEFAULT));
   }
 
   public int getLdapConnectTimeout() {
-    return Integer.parseInt(properties.getProperty("ldap.connect.timeout", LDAP_CONNECT_TIMEOUT));
+    return Integer.parseInt(
+        properties.getProperty("ldap.connect.timeout", LDAP_CONNECT_TIMEOUT_DEFAULT));
   }
 
   public int getLdapResponseTimeout() {
-    return Integer.parseInt(properties.getProperty("ldap.response.timeout", LDAP_RESPONSE_TIMEOUT));
+    return Integer.parseInt(
+        properties.getProperty("ldap.response.timeout", LDAP_RESPONSE_TIMEOUT_DEFAULT));
   }
 
   public int getLdapConnectionPoolMinSize() {
@@ -113,7 +116,8 @@ public class SecurityConfiguration {
 
   public int getSuggestionsReloadSleepMs() {
     return Integer.parseInt(
-        properties.getProperty("nna.suggestions.reload.sleep.ms", NNA_SUGGESTIONS_RELOAD_TIMEOUT));
+        properties.getProperty(
+            "nna.suggestions.reload.sleep.ms", NNA_SUGGESTIONS_RELOAD_TIMEOUT_DEFAULT));
   }
 
   public String getJwtSignatureSecret() {
@@ -193,7 +197,7 @@ public class SecurityConfiguration {
   }
 
   public int getPort() {
-    return Integer.parseInt(properties.getProperty("nna.port", NNA_PORT));
+    return Integer.parseInt(properties.getProperty("nna.port", NNA_PORT_DEFAULT));
   }
 
   public String getHistoricalUsername() {


### PR DESCRIPTION
Make sure you have checked all steps below.

### GitHub Issue
Fixes [#48] Default values for variables of SecuirtyConfiguration

### Checklist:
<!--- Go over all the following points. Check boxes that apply to this pull request -->
- [ ] This pull request updates the documentation
- [X] This pull request changes the code
- [X] Title of the PR is of format (example) : `[#25] Add Pull Request Template`, where `[#25] is the GitHub issue number`

<!-- NOTE: lines that start with < - - ! and end with - - > are comments and will be ignored. -->
<!-- Please include the GitHub issue number in the PR title above. If an issue does not exist, please create one.-->

### What is the purpose of this pull request?
<!-- Please fill in changes proposed in this pull request. -->
<!-- Example: This Pull Request upgrades codebase to spark 3.0.0  -->
Setting following default values for `SecurityConfiguration.java` in case they are not present in `security.properties` file
```
nna.port=8080
nna.historical=false
ldap.enable=false
authorization.enable=false
ldap.use.starttls=false
ldap.connect.timeout=1000
ldap.response.timeout=1000
nna.suggestions.reload.sleep.ms=900000
```

### How was this change validated?
<!-- Please add the Command Used, Results Snippet, details on how reviewer/committer can simulate issue & verify the change -->
<!-- Example: In addition to unit-tests, and integration-test, I ran X on the Y cluster and verified the Z output.-->

### Commit Guidelines
- [X] My commits all reference GH issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

