### PR TITLE
[#128] Document JVM sizing as function of FsImage size

### DIFF
--- a/docs/Getting_Started/How_To_Configure.md
+++ b/docs/Getting_Started/How_To_Configure.md
@@ -6,14 +6,15 @@ The general rule of thumb is to configure your NNA JVM settings exactly as you w
 Typically it is good to follow a sizing guide to configure your heap as a function of your file system load.
 For example:
 
-Number of Files | Java Heap (Xmx + Xms) | Young Gen (-XX:NewSize + -XX:MaxNewSize)
-<1mil - 5mil    | 3379m                 | 512m
-5mil - 20mil    | 10982m                | 1280m
-20mil - 50mil   | 26752m                | 3072m
-50mil - 100mil  | 52659m                | 6144m
-100mil - 150mil | 78566m                | 8960m
-150mil - 250mil | 204800m               | 10240m
-300mil+         | 244800m               | 25600m
+| Number of Files | FsImage | Java Heap (Xmx + Xms) | Young Gen (-XX:NewSize + -XX:MaxNewSize) |
+| --------------- | ------- | :--------------------:| ----------------------------------------:|
+| <1mil - 5mil    | 1-4 GB  | 3379m                 | 512m                                     |
+| 5mil - 20mil    | 4-7 GB  | 10982m                | 1280m                                    |
+| 20mil - 50mil   | 7-10 GB | 26752m                | 3072m                                    |
+| 50mil - 100mil  | 10+ GB  | 52659m                | 6144m                                    |
+| 100mil - 150mil | 15+ GB  | 78566m                | 8960m                                    |
+| 150mil - 250mil | 25+ GB  | 204800m               | 10240m                                   |
+| 300mil+         | 30+ GB  | 244800m               | 25600m                                   |
 
 1. SCP over configurations from your Standby NameNode into `/usr/local/nn-analytics/config`
 2. Modify your `hdfs-site.xml` and ensure that Kerberos information is valid. NNA requires a keytab with `nn` user principal if you are using Kerberos. Just like a real NameNode.


### PR DESCRIPTION
Make sure you have checked all steps below.

### GitHub Issue
Fixes #128 


### Checklist:
<!--- Go over all the following points. Check boxes that apply to this pull request -->
- [X] This pull request updates the documentation
- [ ] This pull request changes the code
- [X] Title of the PR is of format (example) : `[#25] Add Pull Request Template`, where `[#25] is the GitHub issue number`

<!-- NOTE: lines that start with < - - ! and end with - - > are comments and will be ignored. -->
<!-- Please include the GitHub issue number in the PR title above. If an issue does not exist, please create one.-->

### What is the purpose of this pull request?
<!-- Please fill in changes proposed in this pull request. -->
<!-- Example: This Pull Request upgrades codebase to spark 3.0.0  -->

### How was this change validated?
<!-- Please add the Command Used, Results Snippet, details on how reviewer/committer can simulate issue & verify the change -->
<!-- Example: In addition to unit-tests, and integration-test, I ran X on the Y cluster and verified the Z output.-->

### Commit Guidelines
- [X] My commits all reference GH issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

