### PR TITLE
making main method public for nn-analytics to start

### DIFF
--- a/src/main/java/org/apache/hadoop/hdfs/server/namenode/analytics/WebServerMain.java
+++ b/src/main/java/org/apache/hadoop/hdfs/server/namenode/analytics/WebServerMain.java
@@ -162,7 +162,7 @@ public class WebServerMain implements ApplicationMain {
    * @throws IllegalAccessException IllegalAccessException
    * @throws NoSuchFieldException NoSuchFieldException
    */
-  static void main(String[] args)
+  public static void main(String[] args)
       throws InterruptedException, IllegalAccessException, NoSuchFieldException {
     try {
       ApplicationMain main = new WebServerMain();


### PR DESCRIPTION
Minor change to avoid nn-analytics failing to start 

Make sure you have checked all steps below.

### GitHub Issue
Fixes # nn-analytics fails to start


### Checklist:
<!--- Go over all the following points. Check boxes that apply to this pull request -->
- [ ] This pull request updates the documentation
- [x] This pull request changes the code
- [ ] Title of the PR is of format (example) : `[#25] Add Pull Request Template`, where `[#25] is the GitHub issue number`

<!-- NOTE: lines that start with < - - ! and end with - - > are comments and will be ignored. -->
<!-- Please include the GitHub issue number in the PR title above. If an issue does not exist, please create one.-->

### What is the purpose of this pull request?
<!-- Please fill in changes proposed in this pull request. -->
<!-- Example: This Pull Request upgrades codebase to spark 3.0.0  -->
To be able to start the service using nn_loader

### How was this change validated?
<!-- Please add the Command Used, Results Snippet, details on how reviewer/committer can simulate issue & verify the change -->
Did deploy on a UAT cluster and works, before change fails with below error.
```
Listening for transport dt_socket at address: 5005
Error: Main method not found in class org.apache.hadoop.hdfs.server.namenode.analytics.WebServerMain, please define the main method as:
   public static void main(String[] args)
or a JavaFX application class must extend javafx.application.Application
```

<!-- Example: In addition to unit-tests, and integration-test, I ran X on the Y cluster and verified the Z output.-->

### Commit Guidelines
- [x] My commits all reference GH issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

