### PR TITLE
[#198] Remove HortonWorks repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,9 +133,6 @@ compileJava {
 
 repositories {
     mavenCentral()
-    maven {
-        url 'https://repo.hortonworks.com/content/repositories/releases/'
-    }
 }
 
 configurations {


### PR DESCRIPTION
Make sure you have checked all steps below.

### GitHub Issue
Follow up to #198 where it was discovered that the HortonWorks repo is unused.


### Checklist:
<!--- Go over all the following points. Check boxes that apply to this pull request -->
- [ ] This pull request updates the documentation
- [X] This pull request changes the code
- [X] Title of the PR is of format (example) : `[#25] Add Pull Request Template`, where `[#25] is the GitHub issue number`

<!-- NOTE: lines that start with < - - ! and end with - - > are comments and will be ignored. -->
<!-- Please include the GitHub issue number in the PR title above. If an issue does not exist, please create one.-->

### What is the purpose of this pull request?
<!-- Please fill in changes proposed in this pull request. -->
<!-- Example: This Pull Request upgrades codebase to spark 3.0.0  -->

### How was this change validated?
<!-- Please add the Command Used, Results Snippet, details on how reviewer/committer can simulate issue & verify the change -->
<!-- Example: In addition to unit-tests, and integration-test, I ran X on the Y cluster and verified the Z output.-->

### Commit Guidelines
- [X] My commits all reference GH issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

