### PR TITLE
[#243] File type histogram not detecting app logs

### DIFF
--- a/src/main/java/org/apache/hadoop/hdfs/server/namenode/queries/FileTypeHistogram.java
+++ b/src/main/java/org/apache/hadoop/hdfs/server/namenode/queries/FileTypeHistogram.java
@@ -188,6 +188,10 @@ public class FileTypeHistogram {
       if (extIndex != -1 && (key = suffixExtMap.get(name.substring(extIndex))) != null) {
         return key;
       }
+      extIndex = name.lastIndexOf("_");
+      if (extIndex != -1 && (key = suffixExtMap.get(name.substring(extIndex))) != null) {
+        return key;
+      }
     }
     return Types.UNKNOWN.name();
   }

--- a/src/test/java/org/apache/hadoop/hdfs/server/namenode/analytics/TestWithMiniClusterBase.java
+++ b/src/test/java/org/apache/hadoop/hdfs/server/namenode/analytics/TestWithMiniClusterBase.java
@@ -261,8 +261,10 @@ public abstract class TestWithMiniClusterBase {
     assertThat(fileTypeRes.getStatusLine().getStatusCode(), is(200));
     List<String> fileTypeContent = IOUtils.readLines(fileTypeRes.getEntity().getContent());
     long part_r_counts = fileTypeContent.stream().filter(s -> s.startsWith("PART_R")).count();
+    long applog_counts = fileTypeContent.stream().filter(s -> s.startsWith("APP_LOG")).count();
     assertThat(fileTypeContent.size(), is(greaterThan(0)));
     assertThat(part_r_counts, is(greaterThan(0L)));
+    assertThat(applog_counts, is(greaterThan(0L)));
   }
 
   protected void addFiles(int numOfFiles, long sleepBetweenMs) throws Exception {
@@ -276,7 +278,7 @@ public abstract class TestWithMiniClusterBase {
       dirPath = dirPath.suffix("/dir" + dirNumber3);
       fileSystem.mkdirs(dirPath);
       Path filePath = dirPath.suffix("/file" + i);
-      int fileType = RANDOM.nextInt(6);
+      int fileType = RANDOM.nextInt(7);
       switch (fileType) {
         case 0:
           filePath = filePath.suffix(".zip");
@@ -295,14 +297,14 @@ public abstract class TestWithMiniClusterBase {
           break;
         case 5:
           filePath = dirPath.suffix("/part-r-" + i);
+          break;
+        case 6:
+          filePath = filePath.suffix("_45454");
         default:
           break;
       }
       int fileSize = RANDOM.nextInt(4);
       switch (fileSize) {
-        case 0:
-          DFSTestUtil.writeFile(fileSystem, filePath, "");
-          break;
         case 1:
           DFSTestUtil.writeFile(fileSystem, filePath, new String(TINY_FILE_BYTES));
           break;
@@ -312,6 +314,7 @@ public abstract class TestWithMiniClusterBase {
         case 3:
           DFSTestUtil.writeFile(fileSystem, filePath, new String(MEDIUM_FILE_BYTES));
           break;
+        case 0:
         default:
           DFSTestUtil.writeFile(fileSystem, filePath, "");
           break;
@@ -321,14 +324,13 @@ public abstract class TestWithMiniClusterBase {
       }
       int user = RANDOM.nextInt(3);
       switch (user) {
-        case 0:
-          break;
         case 1:
           fileSystem.setOwner(filePath, USERS[0], USERS[0]);
           break;
         case 2:
           fileSystem.setOwner(filePath, USERS[1], USERS[1]);
           break;
+        case 0:
         default:
           break;
       }


### PR DESCRIPTION
Make sure you have checked all steps below.

### GitHub Issue
Fixes #243


### Checklist:
<!--- Go over all the following points. Check boxes that apply to this pull request -->
- [ ] This pull request updates the documentation
- [X] This pull request changes the code
- [X] Title of the PR is of format (example) : `[#25] Add Pull Request Template`, where `[#25] is the GitHub issue number`

<!-- NOTE: lines that start with < - - ! and end with - - > are comments and will be ignored. -->
<!-- Please include the GitHub issue number in the PR title above. If an issue does not exist, please create one.-->

### What is the purpose of this pull request?
<!-- Please fill in changes proposed in this pull request. -->
<!-- Example: This Pull Request upgrades codebase to spark 3.0.0  -->

### How was this change validated?
<!-- Please add the Command Used, Results Snippet, details on how reviewer/committer can simulate issue & verify the change -->
<!-- Example: In addition to unit-tests, and integration-test, I ran X on the Y cluster and verified the Z output.-->

### Commit Guidelines
- [X] My commits all reference GH issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

