### PR TITLE
update maven repo URL   to https 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ apply plugin: 'checkstyle'
 
 buildscript {
     repositories {
-        maven { url = "http://jcenter.bintray.com" }
-        maven { url = "http://repo.maven.apache.org/maven2" }
+        maven { url = "https://jcenter.bintray.com" }
+        maven { url = "https://repo.maven.apache.org/maven2" }
     }
     dependencies {
         classpath 'com.netflix.nebula:gradle-ospackage-plugin:2.2.4'
@@ -132,8 +132,8 @@ compileJava {
 }
 
 repositories {
-    maven { url = "http://jcenter.bintray.com" }
-    maven { url = "http://repo.maven.apache.org/maven2" }
+    maven { url = "https://jcenter.bintray.com" }
+    maven { url = "https://repo.maven.apache.org/maven2" }
 }
 
 configurations {


### PR DESCRIPTION
fix:Requests to http://repo1.maven.org/maven2/ return a 501 HTTPS Required


Effective January 15, 2020, The Central Repository no longer supports insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS.